### PR TITLE
On-demand compatibility with kubernetes 1.0

### DIFF
--- a/manifests/master/apiserver.pp
+++ b/manifests/master/apiserver.pp
@@ -196,6 +196,11 @@
 #   Enable watch caching in the apiserver
 #   Default true
 #
+# [*minimum_version*]
+#   Minimum supported Kubernetes version. Don't enable new features when
+#   incompatbile with that version.
+#   Default to 1.1.
+#
 class kubernetes::master::apiserver (
   $service_cluster_ip_range,
   $ensure                        = $kubernetes::master::params::kube_api_service_ensure,
@@ -241,6 +246,7 @@ class kubernetes::master::apiserver (
   $token_auth_file               = $kubernetes::master::params::kube_api_token_auth_file,
   $watch_cache                   = $kubernetes::master::params::kube_api_watch_cache,
   $extra_args                    = $kubernetes::master::params::kube_api_extra_args,
+  $minimum_version               = $kubernetes::master::params::kube_api_minimum_version,
 ) inherits kubernetes::master::params {
   include ::kubernetes
   include ::kubernetes::master

--- a/manifests/master/controller_manager.pp
+++ b/manifests/master/controller_manager.pp
@@ -125,6 +125,11 @@
 #      deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.
 #   Defaults to 0
 #
+# [*minimum_version*]
+#   Minimum supported Kubernetes version. Don't enable new features when
+#   incompatbile with that version.
+#   Default to 1.1.
+#
 class kubernetes::master::controller_manager (
   $ensure                                = $kubernetes::master::params::kube_controller_service_ensure,
   $enable                                = $kubernetes::master::params::kube_controller_service_enable,
@@ -156,6 +161,7 @@ class kubernetes::master::controller_manager (
   $service_sync_period                   = $kubernetes::master::params::kube_controller_service_sync_period,
   $terminated_pod_gc_threshold           = $kubernetes::master::params::kube_controller_terminated_pod_gc_threshold,
   $extra_args                            = $kubernetes::master::params::kube_controller_args,
+  $minimum_version                       = $kubernetes::master::params::kube_controller_minimum_version,
 ) inherits kubernetes::master::params {
   include ::kubernetes
   include ::kubernetes::master

--- a/manifests/master/params.pp
+++ b/manifests/master/params.pp
@@ -53,6 +53,7 @@ class kubernetes::master::params {
   $kube_api_token_auth_file = undef
   $kube_api_watch_cache = true
   $kube_api_extra_args = ''
+  $kube_api_minimum_version = 1.1
 
   # controller manager config
   # http://kubernetes.io/v1.1/docs/admin/kube-controller-manager.html
@@ -86,6 +87,7 @@ class kubernetes::master::params {
   $kube_controller_service_sync_period = '5m0s'
   $kube_controller_terminated_pod_gc_threshold = 0
   $kube_controller_args = ''
+  $kube_controller_minimum_version = 1.1
 
   # scheduler config
   # http://kubernetes.io/v1.1/docs/admin/kube-scheduler.html
@@ -100,4 +102,5 @@ class kubernetes::master::params {
   $kube_scheduler_master = 'http://127.0.0.1:8080'
   $kube_scheduler_port = 10251
   $kube_scheduler_args = ''
+  $kube_scheduler_minimum_version = 1.1
 }

--- a/manifests/master/scheduler.pp
+++ b/manifests/master/scheduler.pp
@@ -40,6 +40,11 @@
 #   The port that the scheduler's http service runs on
 #   Defaults to 10251
 #
+# [*minimum_version*]
+#   Minimum supported Kubernetes version. Don't enable new features when
+#   incompatbile with that version.
+#   Default to 1.1.
+#
 class kubernetes::master::scheduler (
   $ensure              = $kubernetes::master::params::kube_scheduler_service_ensure,
   $enable              = $kubernetes::master::params::kube_scheduler_service_enable,
@@ -52,6 +57,7 @@ class kubernetes::master::scheduler (
   $master              = $kubernetes::master::params::kube_scheduler_master,
   $port                = $kubernetes::master::params::kube_scheduler_port,
   $extra_args          = $kubernetes::master::params::kube_scheduler_args,
+  $minimum_version     = $kubernetes::master::params::kube_scheduler_minimum_version,
 ) inherits kubernetes::master::params {
   include ::kubernetes
   include ::kubernetes::master

--- a/manifests/node/kube_proxy.pp
+++ b/manifests/node/kube_proxy.pp
@@ -83,6 +83,11 @@
 #   Only applicable for proxy-mode=userspace
 #   Defaults to 250ms
 #
+# [*minimum_version*]
+#   Minimum supported Kubernetes version. Don't enable new features when
+#   incompatbile with that version.
+#   Default to 1.1.
+#
 # [*args*]
 #   Add your own!
 #
@@ -104,6 +109,7 @@ class kubernetes::node::kube_proxy (
   $proxy_port_range     = $kubernetes::node::params::kube_proxy_proxy_port_range,
   $resource_container   = $kubernetes::node::params::kube_proxy_resource_container,
   $udp_timeout          = $kubernetes::node::params::kube_proxy_udp_timeout,
+  $minimum_version      = $kubernetes::node::params::kube_proxy_minimum_version,
   $args                 = $kubernetes::node::params::kube_proxy_args,
 ) inherits kubernetes::node::params {
   include ::kubernetes

--- a/manifests/node/params.pp
+++ b/manifests/node/params.pp
@@ -63,5 +63,6 @@ class kubernetes::node::params {
   $kube_proxy_proxy_port_range = '0-0'
   $kube_proxy_resource_container = undef
   $kube_proxy_udp_timeout = '250ms'
+  $kube_proxy_minimum_version = 1.1
   $kube_proxy_args = ''
 }

--- a/templates/etc/kubernetes/apiserver.erb
+++ b/templates/etc/kubernetes/apiserver.erb
@@ -58,7 +58,9 @@ KUBE_API_ARGS="<% -%>
  --long-running-request-regexp=<%= scope['kubernetes::master::apiserver::long_running_request_regexp'] -%>
 <% end -%>
  --master-service-namespace=<%= scope['kubernetes::master::apiserver::master_service_namespace'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --max-connection-bytes-per-sec=<%= scope['kubernetes::master::apiserver::max_connection_bytes_per_sec'] -%>
+<% end -%>
  --max-requests-inflight=<%= scope['kubernetes::master::apiserver::max_requests_inflight'] -%>
  --min-request-timeout=<%= scope['kubernetes::master::apiserver::min_request_timeout'] -%>
 <% if @runtime_config -%>
@@ -87,6 +89,8 @@ KUBE_API_ARGS="<% -%>
 <% if @token_auth_file -%>
  --token-auth-file=<%= scope['kubernetes::master::apiserver::token_auth_file'] -%>
 <% end -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --watch-cache=<%= scope['kubernetes::master::apiserver::watch_cache'] -%>
+<% end -%>
  <%= scope['kubernetes::master::apiserver::extra_args'] -%>
 "

--- a/templates/etc/kubernetes/controller-manager.erb
+++ b/templates/etc/kubernetes/controller-manager.erb
@@ -16,14 +16,18 @@ KUBE_CONTROLLER_MANAGER_ARGS="<% -%>
 <% end -%>
  --cluster-name=<%= scope['kubernetes::master::controller_manager::cluster_name'] -%>
  --concurrent-endpoint-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_endpoint_syncs'] -%>
- --concurrent_rc_syncs=<%= scope['kubernetes::master::controller_manager::concurrent_rc_syncs'] -%>
+ --concurrent-rc-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_rc_syncs'] -%>
  --deleting-pods-burst=<%= scope['kubernetes::master::controller_manager::deleting_pods_burst'] -%>
  --deleting-pods-qps=<%= scope['kubernetes::master::controller_manager::deleting_pods_qps'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --deployment-controller-sync-period=<%= scope['kubernetes::master::controller_manager::deployment_controller_sync_period'] -%>
+<% end -%>
 <% if @google_json_key then -%>
  --google-json-key=<%= scope['kubernetes::master::controller_manager::google_json_key'] -%>
 <% end -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --horizontal-pod-autoscaler-sync-period=<%= scope['kubernetes::master::controller_manager::horizontal_pod_autoscaler_sync_period'] -%>
+<% end -%>
 <% if @kubeconfig then -%>
  --kubeconfig=<%= scope['kubernetes::master::controller_manager::kubeconfig'] -%>
 <% end -%>
@@ -46,6 +50,8 @@ KUBE_CONTROLLER_MANAGER_ARGS="<% -%>
  --service-account-private-key-file=<%= scope['kubernetes::master::controller_manager::service_account_private_key_file'] -%>
 <% end -%>
  --service-sync-period=<%= scope['kubernetes::master::controller_manager::service_sync_period'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --terminated-pod-gc-threshold=<%= scope['kubernetes::master::controller_manager::terminated_pod_gc_threshold'] -%>
+<% end -%>
 <%= scope['kubernetes::master::controller_manager::extra_args'] -%>
 "

--- a/templates/etc/kubernetes/proxy.erb
+++ b/templates/etc/kubernetes/proxy.erb
@@ -6,19 +6,27 @@
 # Add your own!
 KUBE_PROXY_ARGS="<% -%>
  --bind-address=<%= scope['kubernetes::node::kube_proxy::bind_address'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --cleanup-iptables=<%= scope['kubernetes::node::kube_proxy::cleanup_iptables'] -%>
+<% end -%>
  --healthz-bind-address=<%= scope['kubernetes::node::kube_proxy::healthz_bind_address'] -%>
  --healthz-port=<%= scope['kubernetes::node::kube_proxy::healthz_port'] -%>
 <% if @hostname_override %> --hostname-override=<%= scope['kubernetes::node::kube_proxy::hostname_override'] %><% end -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --iptables-sync-period=<%= scope['kubernetes::node::kube_proxy::iptables_sync_period'] -%>
+<% end -%>
 <% if @kubeconfig %> --kubeconfig=<%= scope['kubernetes::node::kube_proxy::kubeconfig'] %><% end -%>
  --log-flush-frequency=<%= scope['kubernetes::node::kube_proxy::log_flush_frequency'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --masquerade-all=<%= scope['kubernetes::node::kube_proxy::masquerade_all'] -%>
+<% end -%>
  --master=<%= scope['kubernetes::node::kube_proxy::master'] -%>
 <% if @oom_score_adj %> --oom-score-adj=<%= scope['kubernetes::node::kube_proxy::oom_score_adj'] %><% end -%>
 <% if @proxy_mode %> --proxy-mode=<%= scope['kubernetes::node::kube_proxy::proxy_mode'] %><% end -%>
  --proxy-port-range=<%= scope['kubernetes::node::kube_proxy::proxy_port_range'] -%>
 <% if @resource_container %> --resource-container=<%= scope['kubernetes::node::kube_proxy::resource_container'] %><% end -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --udp-timeout=<%= scope['kubernetes::node::kube_proxy::udp_timeout'] -%>
+<% end -%>
  <%= scope['kubernetes::node::kube_proxy::args'] -%>
 "

--- a/templates/etc/kubernetes/scheduler.erb
+++ b/templates/etc/kubernetes/scheduler.erb
@@ -7,8 +7,10 @@
 # Add your own!
 KUBE_SCHEDULER_ARGS="<% -%>
  --address=<%= scope['kubernetes::master::scheduler::address'] -%>
+<% if @minimum_version.to_f > 1.0 then -%>
  --bind-pods-burst=<%= scope['kubernetes::master::scheduler::bind_pods_burst'] -%>
  --bind-pods-qps=<%= scope['kubernetes::master::scheduler::bind_pods_qps'] -%>
+<% end -%>
 <% if @google_json_key then -%>
  --google-json-key=<%= scope['kubernetes::master::scheduler::google_json_key'] -%>
 <% end -%>


### PR DESCRIPTION
The various kubernetes daemons (api-server, scheduler, ...) will refuse
to start in presence of unknown command line flags (like the new options
introduced by kubernetes 1.1, when seen by 1.0 binaries).

This commit allow consumers to request backward compatibility up to
a specified kubernetes version, while allowing the introduction of
new command line flags for up-to-date users.

Being the release chosen by Red Hat for RHEL 7.x, the 1.0 kubernetes
release is here to stay.
