### PR TITLE
Fix kubelet and apiserver templates to use dash instead of underscore

### DIFF
--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -114,10 +114,6 @@
 #   Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains
 #   Default=undef
 #
-# [*hostname_override*]
-#   If non-empty, will use this string as identification instead of the actual hostname.
-#   Default=undef
-#
 # [*http_check_frequency*]
 #   Duration between checking http for new data
 #   Default=undef
@@ -180,7 +176,6 @@ class kubernetes::node::kubelet (
   $tls_private_key_file                  = $kubernetes::node::params::kubelet_tls_private_key_file,
   $cluster_dns                           = $kubernetes::node::params::kubelet_cluster_dns,
   $cluster_domain                        = $kubernetes::node::params::kubelet_cluster_domain,
-  $hostname_override                     = $kubernetes::node::params::kubelet_hostname_override,
   $http_check_frequency                  = $kubernetes::node::params::kubelet_http_check_frequency,
   $manifest_url                          = $kubernetes::node::params::kubelet_manifest_url,
   $master_service_namespace              = $kubernetes::node::params::kubelet_master_service_namespace,

--- a/manifests/node/params.pp
+++ b/manifests/node/params.pp
@@ -31,7 +31,6 @@ class kubernetes::node::params {
   $kubelet_tls_private_key_file = undef
   $kubelet_cluster_dns = undef
   $kubelet_cluster_domain = undef
-  $kubelet_hostname_override = undef
   $kubelet_http_check_frequency = undef
   $kubelet_manifest_url = undef
   $kubelet_master_service_namespace = undef

--- a/templates/etc/kubernetes/apiserver.erb
+++ b/templates/etc/kubernetes/apiserver.erb
@@ -11,17 +11,17 @@ KUBE_API_ADDRESS="--insecure-bind-address=<%= scope['kubernetes::master::apiserv
 KUBE_API_PORT="--insecure-port=<%= scope['kubernetes::master::apiserver::insecure_port'] %>"
 
 # Port minions listen on
-KUBELET_PORT="--kubelet_port=<%= scope['kubernetes::master::apiserver::kubelet_port'] %>"
+KUBELET_PORT="--kubelet-port=<%= scope['kubernetes::master::apiserver::kubelet_port'] %>"
 
 # we don't use --etcd_servers. Instead we use --etcd-config
 # Comma separated list of nodes in the etcd cluster
-#KUBE_ETCD_SERVERS="--etcd_servers=http://127.0.0.1:2379"
+#KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=<%= scope['kubernetes::master::apiserver::service_cluster_ip_range'] %>"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission_control=<%= Array(scope['kubernetes::master::apiserver::admission_control']).join(',') %>"
+KUBE_ADMISSION_CONTROL="--admission-control=<%= Array(scope['kubernetes::master::apiserver::admission_control']).join(',') %>"
 
 # Add your own!
 KUBE_API_ARGS="<% -%>

--- a/templates/etc/kubernetes/kubelet.erb
+++ b/templates/etc/kubernetes/kubelet.erb
@@ -8,10 +8,10 @@ KUBELET_ADDRESS="--address=<%= scope['kubernetes::node::kubelet::address'] %>"
 KUBELET_PORT="--port=<%= scope['kubernetes::node::kubelet::port'] %>"
 
 # You may leave this blank to use the actual hostname
-KUBELET_HOSTNAME="--hostname_override=<%= scope['kubernetes::node::kubelet::hostname'] %>"
+KUBELET_HOSTNAME="--hostname-override=<%= scope['kubernetes::node::kubelet::hostname'] %>"
 
 # location of the api-server
-KUBELET_API_SERVER="--api_servers=<%= Array(scope['kubernetes::node::kubelet::api_servers']).join(',') %>"
+KUBELET_API_SERVER="--api-servers=<%= Array(scope['kubernetes::node::kubelet::api_servers']).join(',') %>"
 
 # Add your own!
 KUBELET_ARGS="<% -%>

--- a/templates/etc/kubernetes/kubelet.erb
+++ b/templates/etc/kubernetes/kubelet.erb
@@ -56,9 +56,6 @@ KUBELET_ARGS="<% -%>
 <% if @cluster_domain -%>
  --cluster-domain=<%= scope['kubernetes::node::kubelet::cluster_domain'] -%>
 <% end -%>
-<% if @hostname_override -%>
- --hostname-override=<%= scope['kubernetes::node::kubelet::hostname_override'] -%>
-<% end -%>
 <% if @http_check_frequency -%>
  --http-check-frequency=<%= scope['kubernetes::node::kubelet::http_check_frequency'] -%>
 <% end -%>


### PR DESCRIPTION
I have fixed templates to use - as word separator, but I am not sure what to do with `KUBELET_HOSTNAME="--hostname-override`. It is specified in two places in the same template. 
