### PR TITLE
Support Kubernetes 1.2

### DIFF
--- a/manifests/master/apiserver.pp
+++ b/manifests/master/apiserver.pp
@@ -196,6 +196,30 @@
 #   Enable watch caching in the apiserver
 #   Default true
 #
+# [*watch_cache_sizes*]
+#   List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. The individual override format: resource#size, where size is a number. It takes effect when watch-cache is enabled.
+#   Default undef
+#
+# [*repair_malformed_updates*]
+#   If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates.
+#   Default true
+#
+# [*delete_collection_workers*]
+#   Number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.
+#   Default 1
+#
+# [*kubernetes_service_node_port*]
+#   If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.
+#   Default 0
+#
+# [*authorization_webhook_config*]
+#   File with webhook configuration in kubeconfig format, used with --authorization-mode=Webhook. The API server will query the remote service to determine access on the API server's secure port.
+#   Default undef
+#
+# [*ir_hawkular*]
+#   Hawkular configuration URL
+#   Default undef
+#
 # [*minimum_version*]
 #   Minimum supported Kubernetes version. Don't enable new features when
 #   incompatbile with that version.
@@ -247,6 +271,12 @@ class kubernetes::master::apiserver (
   $watch_cache                   = $kubernetes::master::params::kube_api_watch_cache,
   $extra_args                    = $kubernetes::master::params::kube_api_extra_args,
   $minimum_version               = $kubernetes::master::params::kube_api_minimum_version,
+  $watch_cache_sizes             = $kubernetes::master::params::kube_api_watch_cache_sizes,
+  $repair_malformed_updates      = $kubernetes::master::params::kube_api_repair_malformed_updates,
+  $delete_collection_workers     = $kubernetes::master::params::kube_api_delete_collection_workers,
+  $kubernetes_service_node_port  = $kubernetes::master::params::kube_api_kubernetes_service_node_port,
+  $authorization_webhook_config  = $kubernetes::master::params::kube_api_authorization_webhook_config,
+  $ir_hawkular                   = $kubernetes::master::params::kube_api_ir_hawkular,
 ) inherits kubernetes::master::params {
   include ::kubernetes::master
 

--- a/manifests/master/controller_manager.pp
+++ b/manifests/master/controller_manager.pp
@@ -125,6 +125,54 @@
 #      deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.
 #   Defaults to 0
 #
+# [*concurrent_deployment_syncs*]
+#   The number of deployment objects that are allowed to sync concurrently. Larger number = more responsive deployments, but more CPU (and network) load
+#   Default 5
+#
+# [*concurrent_namespace_syncs*]
+#   The number of namespace objects that are allowed to sync concurrently. Larger number = more responsive namespace termination, but more CPU (and network) load
+#   Default 2
+#
+# [*concurrent_replicaset_syncs*]
+#   The number of replica sets that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load
+#   Default 5
+#
+# [*concurrent_resource_quota_syncs*]
+#   The number of resource quotas that are allowed to sync concurrently. Larger number = more responsive quota management, but more CPU (and network) load
+#   Default 5
+#
+# [*daemonset_lookup_cache_size*]
+#   The the size of lookup cache for daemonsets. Larger number = more responsive daemonsets, but more MEM load.
+#   Default 1024
+#
+# [*kube_api_burst*]
+#   Burst to use while talking with kubernetes apiserver
+#   Default 30
+#
+# [*kube_api_qps*]
+#   QPS to use while talking with kubernetes apiserver
+#   Default 20
+#
+# [*leader_elect*]
+#   Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.
+#   Default undef
+#
+# [*leader_elect_lease_duration*]
+#   The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.
+#   Default '15s'
+#
+# [*leader_elect_renew_deadline*]
+#   The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.
+#   Default '10s'
+#
+# [*leader_elect_retry_period*]
+#   The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.
+#   Default '2s'
+#
+# [*replicaset_lookup_cache_size*]
+#   The the size of lookup cache for replicatsets. Larger number = more responsive replica management, but more MEM load.
+#   Default 4096
+#
 # [*minimum_version*]
 #   Minimum supported Kubernetes version. Don't enable new features when
 #   incompatbile with that version.
@@ -160,6 +208,18 @@ class kubernetes::master::controller_manager (
   $service_account_private_key_file      = $kubernetes::master::params::kube_controller_service_account_private_key_file,
   $service_sync_period                   = $kubernetes::master::params::kube_controller_service_sync_period,
   $terminated_pod_gc_threshold           = $kubernetes::master::params::kube_controller_terminated_pod_gc_threshold,
+  $concurrent_deployment_syncs           = $kubernetes::master::params::kube_controller_concurrent_deployment_syncs,
+  $concurrent_namespace_syncs            = $kubernetes::master::params::kube_controller_concurrent_namespace_syncs,
+  $concurrent_replicaset_syncs           = $kubernetes::master::params::kube_controller_concurrent_replicaset_syncs,
+  $concurrent_resource_quota_syncs       = $kubernetes::master::params::kube_controller_concurrent_resource_quota_syncs,
+  $daemonset_lookup_cache_size           = $kubernetes::master::params::kube_controller_daemonset_lookup_cache_size,
+  $kube_api_burst                        = $kubernetes::master::params::kube_controller_kube_api_burst,
+  $kube_api_qps                          = $kubernetes::master::params::kube_controller_kube_api_qps,
+  $leader_elect                          = $kubernetes::master::params::kube_controller_leader_elect,
+  $leader_elect_lease_duration           = $kubernetes::master::params::kube_controller_leader_elect_lease_duration,
+  $leader_elect_renew_deadline           = $kubernetes::master::params::kube_controller_leader_elect_renew_deadline,
+  $leader_elect_retry_period             = $kubernetes::master::params::kube_controller_leader_elect_retry_period,
+  $replicaset_lookup_cache_size          = $kubernetes::master::params::kube_controller_replicaset_lookup_cache_size,
   $extra_args                            = $kubernetes::master::params::kube_controller_args,
   $minimum_version                       = $kubernetes::master::params::kube_controller_minimum_version,
 ) inherits kubernetes::master::params {

--- a/manifests/master/params.pp
+++ b/manifests/master/params.pp
@@ -52,6 +52,12 @@ class kubernetes::master::params {
   $kube_api_tls_private_key_file = undef
   $kube_api_token_auth_file = undef
   $kube_api_watch_cache = true
+  $kube_api_watch_cache_sizes = undef
+  $kube_api_repair_malformed_updates = true
+  $kube_api_delete_collection_workers = 1
+  $kube_api_kubernetes_service_node_port = 0
+  $kube_api_authorization_webhook_config = undef
+  $kube_api_ir_hawkular = undef
   $kube_api_extra_args = ''
   $kube_api_minimum_version = 1.1
 
@@ -86,6 +92,18 @@ class kubernetes::master::params {
   $kube_controller_service_account_private_key_file = undef
   $kube_controller_service_sync_period = '5m0s'
   $kube_controller_terminated_pod_gc_threshold = 0
+  $kube_controller_concurrent_deployment_syncs = 5
+  $kube_controller_concurrent_namespace_syncs = 2
+  $kube_controller_concurrent_replicaset_syncs = 5
+  $kube_controller_concurrent_resource_quota_syncs = 5
+  $kube_controller_daemonset_lookup_cache_size = 1024
+  $kube_controller_kube_api_burst = 30
+  $kube_controller_kube_api_qps = 20
+  $kube_controller_leader_elect = undef
+  $kube_controller_leader_elect_lease_duration = '15s'
+  $kube_controller_leader_elect_renew_deadline = '10s'
+  $kube_controller_leader_elect_retry_period = '2s'
+  $kube_controller_replicaset_lookup_cache_size = 4096
   $kube_controller_args = ''
   $kube_controller_minimum_version = 1.1
 
@@ -101,6 +119,11 @@ class kubernetes::master::params {
   $kube_scheduler_log_flush_frequency = '5s'
   $kube_scheduler_master = 'http://127.0.0.1:8080'
   $kube_scheduler_port = 10251
+  $kube_scheduler_leader_elect = undef
+  $kube_scheduler_leader_elect_lease_duration = '15s'
+  $kube_scheduler_leader_elect_renew_deadline = '10s'
+  $kube_scheduler_leader_elect_retry_period = '2s'
+  $kube_scheduler_scheduler_name = undef
   $kube_scheduler_args = ''
   $kube_scheduler_minimum_version = 1.1
 }

--- a/manifests/master/scheduler.pp
+++ b/manifests/master/scheduler.pp
@@ -40,24 +40,49 @@
 #   The port that the scheduler's http service runs on
 #   Defaults to 10251
 #
+# [*leader_elect*]
+#   Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.
+#   Defaults to undef
+#
+# [*leader_elect_lease_duration*]
+#   The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.
+#   Defaults to '15s'
+#
+# [*leader_elect_renew_deadline*]
+#   The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.
+#   Defaults to '10s'
+#
+# [*leader_elect_retry_period*]
+#   The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.
+#   Defaults to '2s"
+#
+# [*scheduler_name*]
+#   Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's annotation with key 'scheduler.alpha.kubernetes.io/name'
+#   Defaults to undef
+#
 # [*minimum_version*]
 #   Minimum supported Kubernetes version. Don't enable new features when
 #   incompatbile with that version.
 #   Default to 1.1.
 #
 class kubernetes::master::scheduler (
-  $ensure              = $kubernetes::master::params::kube_scheduler_service_ensure,
-  $enable              = $kubernetes::master::params::kube_scheduler_service_enable,
-  $address             = $kubernetes::master::params::kube_scheduler_address,
-  $bind_pods_burst     = $kubernetes::master::params::kube_scheduler_bind_pods_burst,
-  $bind_pods_qps       = $kubernetes::master::params::kube_scheduler_bind_pods_qps,
-  $google_json_key     = $kubernetes::master::params::kube_scheduler_google_json_key,
-  $kubeconfig          = $kubernetes::master::params::kube_scheduler_kubeconfig,
-  $log_flush_frequency = $kubernetes::master::params::kube_scheduler_log_flush_frequency,
-  $master              = $kubernetes::master::params::kube_scheduler_master,
-  $port                = $kubernetes::master::params::kube_scheduler_port,
-  $extra_args          = $kubernetes::master::params::kube_scheduler_args,
-  $minimum_version     = $kubernetes::master::params::kube_scheduler_minimum_version,
+  $ensure                      = $kubernetes::master::params::kube_scheduler_service_ensure,
+  $enable                      = $kubernetes::master::params::kube_scheduler_service_enable,
+  $address                     = $kubernetes::master::params::kube_scheduler_address,
+  $bind_pods_burst             = $kubernetes::master::params::kube_scheduler_bind_pods_burst,
+  $bind_pods_qps               = $kubernetes::master::params::kube_scheduler_bind_pods_qps,
+  $google_json_key             = $kubernetes::master::params::kube_scheduler_google_json_key,
+  $kubeconfig                  = $kubernetes::master::params::kube_scheduler_kubeconfig,
+  $log_flush_frequency         = $kubernetes::master::params::kube_scheduler_log_flush_frequency,
+  $master                      = $kubernetes::master::params::kube_scheduler_master,
+  $port                        = $kubernetes::master::params::kube_scheduler_port,
+  $leader_elect                = $kubernetes::master::params::kube_scheduler_leader_elect,
+  $leader_elect_lease_duration = $kubernetes::master::params::kube_scheduler_leader_elect_lease_duration,
+  $leader_elect_renew_deadline = $kubernetes::master::params::kube_scheduler_leader_elect_renew_deadline,
+  $leader_elect_retry_period   = $kubernetes::master::params::kube_scheduler_leader_elect_retry_period,
+  $scheduler_name              = $kubernetes::master::params::kube_scheduler_scheduler_name,
+  $extra_args                  = $kubernetes::master::params::kube_scheduler_args,
+  $minimum_version             = $kubernetes::master::params::kube_scheduler_minimum_version,
 ) inherits kubernetes::master::params {
   include ::kubernetes::master
 

--- a/manifests/node/kube_proxy.pp
+++ b/manifests/node/kube_proxy.pp
@@ -83,6 +83,30 @@
 #   Only applicable for proxy-mode=userspace
 #   Defaults to 250ms
 #
+# [*config_sync_period*]
+#   How often configuration from the apiserver is refreshed.
+#   Default undef
+#
+# [*conntrack_max*]
+#   Maximum number of NAT connections to track
+#   Default undef
+#
+# [*conntrack_tcp_timeout_established*]
+#   Idle timeout for established TCP connections
+#   Default undef
+#
+# [*iptables_masquerade_bit*]
+#   If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].
+#   Default undef
+#
+# [*kube_api_burst*]
+#   Burst to use while talking with kubernetes apiserver
+#   Default undef
+#
+# [*kube_api_qps*]
+#   QPS to use while talking with kubernetes apiserver
+#   Default undef
+#
 # [*minimum_version*]
 #   Minimum supported Kubernetes version. Don't enable new features when
 #   incompatbile with that version.
@@ -92,25 +116,31 @@
 #   Add your own!
 #
 class kubernetes::node::kube_proxy (
-  $ensure               = $kubernetes::node::params::kube_proxy_service_ensure,
-  $enable               = $kubernetes::node::params::kube_proxy_service_enable,
-  $bind_address         = $kubernetes::node::params::kube_proxy_bind_address,
-  $cleanup_iptables     = $kubernetes::node::params::kube_proxy_cleanup_iptables,
-  $healthz_bind_address = $kubernetes::node::params::kube_proxy_healthz_bind_address,
-  $healthz_port         = $kubernetes::node::params::kube_proxy_healthz_port,
-  $hostname_override    = $kubernetes::node::params::kube_proxy_hostname_override,
-  $iptables_sync_period = $kubernetes::node::params::kube_proxy_iptables_sync_period,
-  $kubeconfig           = $kubernetes::node::params::kube_proxy_kubeconfig,
-  $log_flush_frequency  = $kubernetes::node::params::kube_proxy_log_flush_frequency,
-  $masquerade_all       = $kubernetes::node::params::kube_proxy_masquerade_all,
-  $master               = $kubernetes::node::params::kube_proxy_master,
-  $oom_score_adj        = $kubernetes::node::params::kube_proxy_oom_score_adj,
-  $proxy_mode           = $kubernetes::node::params::kube_proxy_proxy_mode,
-  $proxy_port_range     = $kubernetes::node::params::kube_proxy_proxy_port_range,
-  $resource_container   = $kubernetes::node::params::kube_proxy_resource_container,
-  $udp_timeout          = $kubernetes::node::params::kube_proxy_udp_timeout,
-  $minimum_version      = $kubernetes::node::params::kube_proxy_minimum_version,
-  $args                 = $kubernetes::node::params::kube_proxy_args,
+  $ensure                            = $kubernetes::node::params::kube_proxy_service_ensure,
+  $enable                            = $kubernetes::node::params::kube_proxy_service_enable,
+  $bind_address                      = $kubernetes::node::params::kube_proxy_bind_address,
+  $cleanup_iptables                  = $kubernetes::node::params::kube_proxy_cleanup_iptables,
+  $healthz_bind_address              = $kubernetes::node::params::kube_proxy_healthz_bind_address,
+  $healthz_port                      = $kubernetes::node::params::kube_proxy_healthz_port,
+  $hostname_override                 = $kubernetes::node::params::kube_proxy_hostname_override,
+  $iptables_sync_period              = $kubernetes::node::params::kube_proxy_iptables_sync_period,
+  $kubeconfig                        = $kubernetes::node::params::kube_proxy_kubeconfig,
+  $log_flush_frequency               = $kubernetes::node::params::kube_proxy_log_flush_frequency,
+  $masquerade_all                    = $kubernetes::node::params::kube_proxy_masquerade_all,
+  $master                            = $kubernetes::node::params::kube_proxy_master,
+  $oom_score_adj                     = $kubernetes::node::params::kube_proxy_oom_score_adj,
+  $proxy_mode                        = $kubernetes::node::params::kube_proxy_proxy_mode,
+  $proxy_port_range                  = $kubernetes::node::params::kube_proxy_proxy_port_range,
+  $resource_container                = $kubernetes::node::params::kube_proxy_resource_container,
+  $udp_timeout                       = $kubernetes::node::params::kube_proxy_udp_timeout,
+  $config_sync_period                = $kubernetes::node::params::kube_proxy_config_sync_period,
+  $conntrack_max                     = $kubernetes::node::params::kube_proxy_conntrack_max,
+  $conntrack_tcp_timeout_established = $kubernetes::node::params::kube_proxy_conntrack_tcp_timeout_established,
+  $iptables_masquerade_bit           = $kubernetes::node::params::kube_proxy_iptables_masquerade_bit,
+  $kube_api_burst                    = $kubernetes::node::params::kube_proxy_kube_api_burst,
+  $kube_api_qps                      = $kubernetes::node::params::kube_proxy_kube_api_qps,
+  $minimum_version                   = $kubernetes::node::params::kube_proxy_minimum_version,
+  $args                              = $kubernetes::node::params::kube_proxy_args,
 ) inherits kubernetes::node::params {
   include ::kubernetes::node
 

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -146,6 +146,91 @@
 #   Max period between synchronizing running containers and config
 #   Default=undef
 #
+# [*application_metrics_count_limit*]
+#   Max number of application metrics to store (per container)
+#   Default 100
+#
+# [*docker_env_metadata_whitelist*]
+#   A comma-separated list of environment variable keys that needs to be collected for docker containers
+#   Default undef
+#
+# [*enable_custom_metrics[*]
+#   Support for gathering custom metrics.
+#   Default undef
+#
+# [*experimental_flannel_overlay[*]
+#   Experimental support for starting the kubelet with the default overlay network (flannel). Assumes flanneld is already running in client mode.
+#   Default undef
+#
+# [*hairpin_mode*]
+#   How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are "promiscuous-bridge", "hairpin-veth" and "none".
+#   Default undef
+#
+# [*housekeeping_interval*]
+#   Interval between container housekeepings
+#   Default '10s'
+#
+# [*kube_api_burst*]
+#   Burst to use while talking with kubernetes apiserver
+#   Default undef
+#
+# [*kube_api_qps*]
+#   QPS to use while talking with kubernetes apiserver
+#   Default undef
+#
+# [*kube_reserved*]
+#   A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs that describe resources reserved for kubernetes system components. Currently only cpu and memory are supported.
+#   Default undef
+#
+# [*kubelet_cgroups*]
+#   Optional absolute name of cgroups to create and run the Kubelet in.
+#   Default undef
+#
+# [*lock_file*]
+#   Warning: Alpha feature. The path to file for kubelet to use as a lock file.
+#   Default undef
+#
+# [*minimum_image_ttl_duration*]
+#   Minimum age for a unused image before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'.
+#   Default undef
+#
+# [*node_ip*]
+#   IP address of the node. If set, kubelet will use this IP address for the node
+#   Default undef
+#
+# [*node_labels*]
+#   Warning: Alpha feature. Labels to add when registering the node in the cluster.  Labels must be key=value pairs separated by ','.
+#   Default undef
+#
+# [*reconcile_cidr*]
+#   Reconcile node CIDR with the CIDR specified by the API server. No-op if register-node or configure-cbr0 is false.
+#   Default undef
+#
+# [*register_schedulable[*]
+#   Register the node as schedulable. No-op if register-node is false.
+#   Default undef
+#
+# [*runtime_cgroups*]
+#   Optional absolute name of cgroups to create and run the runtime in.
+#   Default undef
+#
+# [*system_cgroups*]
+#   Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under `/`. Empty for no container. Rolling back the flag requires a reboot.
+#   Default undef
+#
+# [*system_reserved*]
+#   A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported.
+#   Default undef
+#
+# [*non_masquerade_cidr*]
+#   Traffic to IPs outside this range will use IP masquerade.
+#   Default undef
+#
+# [*minimum_version*]
+#   Minimum supported Kubernetes version. Don't enable new features when
+#   incompatbile with that version.
+#   Default to 1.1.
+#
 # [*args*]
 #   Add your own!
 
@@ -184,6 +269,26 @@ class kubernetes::node::kubelet (
   $root_dir                              = $kubernetes::node::params::kubelet_root_dir,
   $streaming_connection_idle_timeout     = $kubernetes::node::params::kubelet_streaming_connection_idle_timeout,
   $sync_frequency                        = $kubernetes::node::params::kubelet_sync_frequency,
+  $application_metrics_count_limit       = $kubernetes::node::params::kubelet_application_metrics_count_limit,
+  $docker_env_metadata_whitelist         = $kubernetes::node::params::kubelet_docker_env_metadata_whitelist,
+  $enable_custom_metrics                 = $kubernetes::node::params::kubelet_enable_custom_metrics,
+  $experimental_flannel_overlay          = $kubernetes::node::params::kubelet_experimental_flannel_overlay,
+  $hairpin_mode                          = $kubernetes::node::params::kubelet_hairpin_mode,
+  $housekeeping_interval                 = $kubernetes::node::params::kubelet_housekeeping_interval,
+  $kube_api_burst                        = $kubernetes::node::params::kubelet_kube_api_burst,
+  $kube_api_qps                          = $kubernetes::node::params::kubelet_kube_api_qps,
+  $kube_reserved                         = $kubernetes::node::params::kubelet_kube_reserved,
+  $kubelet_cgroups                       = $kubernetes::node::params::kubelet_kubelet_cgroups,
+  $lock_file                             = $kubernetes::node::params::kubelet_lock_file,
+  $minimum_image_ttl_duration            = $kubernetes::node::params::kubelet_minimum_image_ttl_duration,
+  $node_ip                               = $kubernetes::node::params::kubelet_node_ip,
+  $node_labels                           = $kubernetes::node::params::kubelet_node_labels,
+  $reconcile_cidr                        = $kubernetes::node::params::kubelet_reconcile_cidr,
+  $register_schedulable                  = $kubernetes::node::params::kubelet_register_schedulable,
+  $runtime_cgroups                       = $kubernetes::node::params::kubelet_runtime_cgroups,
+  $system_cgroups                        = $kubernetes::node::params::kubelet_system_cgroups,
+  $system_reserved                       = $kubernetes::node::params::kubelet_system_reserved,
+  $minimum_version                       = $kubernetes::node::params::kubelet_minimum_version,
   $args                                  = $kubernetes::node::params::kubelet_args,
 ) inherits kubernetes::node::params {
   include ::kubernetes::node

--- a/manifests/node/params.pp
+++ b/manifests/node/params.pp
@@ -39,6 +39,27 @@ class kubernetes::node::params {
   $kubelet_root_dir = undef
   $kubelet_streaming_connection_idle_timeout = undef
   $kubelet_sync_frequency = undef
+  $kubelet_application_metrics_count_limit = 100
+  $kubelet_docker_env_metadata_whitelist = undef
+  $kubelet_enable_custom_metrics = undef
+  $kubelet_experimental_flannel_overlay = undef
+  $kubelet_hairpin_mode = undef
+  $kubelet_housekeeping_interval = '10s'
+  $kubelet_kube_api_burst = undef
+  $kubelet_kube_api_qps = undef
+  $kubelet_kube_reserved = undef
+  $kubelet_kubelet_cgroups = undef
+  $kubelet_lock_file = undef
+  $kubelet_minimum_image_ttl_duration = undef
+  $kubelet_node_ip = undef
+  $kubelet_node_labels = undef
+  $kubelet_reconcile_cidr = undef
+  $kubelet_register_schedulable = undef
+  $kubelet_runtime_cgroups = undef
+  $kubelet_system_cgroups = undef
+  $kubelet_system_reserved = undef
+  $kubelet_non_masquerade_cidr = undef
+  $kubelet_minimum_version = 1.1
   $kubelet_args = ''
 
   # proxy options
@@ -60,6 +81,12 @@ class kubernetes::node::params {
   $kube_proxy_proxy_port_range = '0-0'
   $kube_proxy_resource_container = undef
   $kube_proxy_udp_timeout = '250ms'
+  $kube_proxy_config_sync_period = undef
+  $kube_proxy_conntrack_max = undef
+  $kube_proxy_conntrack_tcp_timeout_established = undef
+  $kube_proxy_iptables_masquerade_bit = undef
+  $kube_proxy_kube_api_burst = undef
+  $kube_proxy_kube_api_qps = undef
   $kube_proxy_minimum_version = 1.1
   $kube_proxy_args = ''
 }

--- a/templates/etc/kubernetes/apiserver.erb
+++ b/templates/etc/kubernetes/apiserver.erb
@@ -13,10 +13,6 @@ KUBE_API_PORT="--insecure-port=<%= scope['kubernetes::master::apiserver::insecur
 # Port minions listen on
 KUBELET_PORT="--kubelet-port=<%= scope['kubernetes::master::apiserver::kubelet_port'] %>"
 
-# we don't use --etcd_servers. Instead we use --etcd-config
-# Comma separated list of nodes in the etcd cluster
-#KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
-
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=<%= scope['kubernetes::master::apiserver::service_cluster_ip_range'] %>"
 
@@ -25,7 +21,17 @@ KUBE_ADMISSION_CONTROL="--admission-control=<%= Array(scope['kubernetes::master:
 
 # Add your own!
 KUBE_API_ARGS="<% -%>
+<% if @minimum_version.to_f < 1.2 then -%>
  --etcd-config=/etc/kubernetes/etcd_config.json<% -%>
+<% end -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+ --etcd-servers=<%= Array(scope['kubernetes::master::apiserver::etcd_servers']).join(',') -%>
+<% if @etcd_certfile and @etcd_keyfile and @etcd_cacertfiles and not Array(@etcd_cacertfiles).flatten.empty? -%>
+ --etcd-certfile=<%= scope['kubernetes::master::apiserver::etcd_certfile'] -%>
+ --etcd-keyfile=<%= scope['kubernetes::master::apiserver::etcd_keyfile'] -%>
+ --etcd-cafile=<%= Array(scope['kubernetes::master::apiserver::etcd_cacertfiles'])[0] -%>
+<% end -%>
+<% end -%>
 <% if @advertise_address then -%>
  --advertise-address=<%= scope['kubernetes::master::apiserver::advertise_address'] -%>
 <% end -%>
@@ -36,7 +42,9 @@ KUBE_API_ARGS="<% -%>
 <% if @client_ca_file then -%>
  --client-ca-file=<%= scope['kubernetes::master::apiserver::client_ca_file'] -%>
 <% end -%>
+<% if @minimum_version.to_f < 1.2 then -%>
  --cluster-name=<%= scope['kubernetes::master::apiserver::cluster_name'] -%>
+<% end -%>
  --etcd-prefix=<%= scope['kubernetes::master::apiserver::etcd_prefix'] -%>
  --event-ttl=<%= scope['kubernetes::master::apiserver::event_ttl'] -%>
 <% if @google_json_key -%>
@@ -91,6 +99,20 @@ KUBE_API_ARGS="<% -%>
 <% end -%>
 <% if @minimum_version.to_f > 1.0 then -%>
  --watch-cache=<%= scope['kubernetes::master::apiserver::watch_cache'] -%>
+<% end -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+ --repair-malformed-updates=<%= scope['kubernetes::master::apiserver::repair_malformed_updates'] -%>
+ --delete-collection-workers==<%= scope['kubernetes::master::apiserver::delete_collection_workers'] -%>
+ --kubernetes-service-node-port=<%= scope['kubernetes::master::apiserver::kubernetes_service_node_port'] -%>
+<% if @watch_cache_sizes -%>
+ --watch-cache-sizes=<%= scope['kubernetes::master::apiserver::watch_cache_sizes'] -%>
+<% end -%>
+<% if @authorization_webhook_config -%>
+ --authorization-webhook-config-file=<%= scope['kubernetes::master::apiserver::authorization_webhook_config'] -%>
+<% end -%>
+<% if @ir_hawkular -%>
+ --ir-hawkular=<%= scope['kubernetes::master::apiserver::ir_hawkular'] -%>
+<% end -%>
 <% end -%>
  <%= scope['kubernetes::master::apiserver::extra_args'] -%>
 "

--- a/templates/etc/kubernetes/controller-manager.erb
+++ b/templates/etc/kubernetes/controller-manager.erb
@@ -53,5 +53,21 @@ KUBE_CONTROLLER_MANAGER_ARGS="<% -%>
 <% if @minimum_version.to_f > 1.0 then -%>
  --terminated-pod-gc-threshold=<%= scope['kubernetes::master::controller_manager::terminated_pod_gc_threshold'] -%>
 <% end -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+ --concurrent-deployment-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_deployment_syncs'] -%>
+ --concurrent-namespace-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_namespace_syncs'] -%>
+ --concurrent-replicaset-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_replicaset_syncs'] -%>
+ --concurrent-resource-quota-syncs=<%= scope['kubernetes::master::controller_manager::concurrent_resource_quota_syncs'] -%>
+ --daemonset-lookup-cache-size=<%= scope['kubernetes::master::controller_manager::daemonset_lookup_cache_size'] -%>
+ --kube-api-burst=<%= scope['kubernetes::master::controller_manager::kube_api_burst'] -%>
+ --kube-api-qps=<%= scope['kubernetes::master::controller_manager::kube_api_qps'] -%>
+ --replicaset-lookup-cache-size=<%= scope['kubernetes::master::controller_manager::replicaset_lookup_cache_size'] -%>
+<% if @leader_elect then -%>
+ --leader-elect=<%= scope['kubernetes::master::controller_manager::leader_elect'] -%>
+ --leader-elect-lease-duration=<%= scope['kubernetes::master::controller_manager::leader_elect_lease_duration'] -%>
+ --leader-elect-renew-deadline=<%= scope['kubernetes::master::controller_manager::leader_elect_renew_deadline'] -%>
+ --leader-elect-retry-period=<%= scope['kubernetes::master::controller_manager::leader_elect_retry_period'] -%>
+<% end -%>
+<% end -%>
 <%= scope['kubernetes::master::controller_manager::extra_args'] -%>
 "

--- a/templates/etc/kubernetes/kubelet.erb
+++ b/templates/etc/kubernetes/kubelet.erb
@@ -80,5 +80,67 @@ KUBELET_ARGS="<% -%>
 <% if @sync_frequency -%>
  --sync-frequency=<%= scope['kubernetes::node::kubelet::sync_frequency'] -%>
 <% end -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+<% if @application_metrics_count_limit -%>
+ --application-metrics-count-limit=<%= scope['kubernetes::node::kubelet::application_metrics_count_limit'] -%>
+<% end -%>
+<% if @docker_env_metadata_whitelist -%>
+ --docker-env-metadata-whitelist=<%= scope['kubernetes::node::kubelet::docker_env_metadata_whitelist'] -%>
+<% end -%>
+<% if @enable_custom_metrics -%>
+ --enable-custom-metrics=<%= scope['kubernetes::node::kubelet::enable_custom_metrics'] -%>
+<% end -%>
+<% if @experimental_flannel_overlay -%>
+ --experimental-flannel-overlay=<%= scope['kubernetes::node::kubelet::experimental_flannel_overlay'] -%>
+<% end -%>
+<% if @hairpin_mode -%>
+ --hairpin-mode=<%= scope['kubernetes::node::kubelet::hairpin_mode'] -%>
+<% end -%>
+<% if @housekeeping_interval -%>
+ --housekeeping-interval=<%= scope['kubernetes::node::kubelet::housekeeping_interval'] -%>
+<% end -%>
+<% if @kube_api_burst -%>
+ --kube-api-burst=<%= scope['kubernetes::node::kubelet::kube_api_burst'] -%>
+<% end -%>
+<% if @kube_api_qps -%>
+ --kube-api-qps=<%= scope['kubernetes::node::kubelet::kube_api_qps'] -%>
+<% end -%>
+<% if @kube_reserved -%>
+ --kube-reserved=<%= scope['kubernetes::node::kubelet::kube_reserved'] -%>
+<% end -%>
+<% if @kubelet_cgroups -%>
+ --kubelet-cgroups=<%= scope['kubernetes::node::kubelet::kubelet_cgroups'] -%>
+<% end -%>
+<% if @lock_file -%>
+ --lock-file=<%= scope['kubernetes::node::kubelet::lock_file'] -%>
+<% end -%>
+<% if @minimum_image_ttl_duration -%>
+ --minimum-image-ttl-duration=<%= scope['kubernetes::node::kubelet::minimum_image_ttl_duration'] -%>
+<% end -%>
+<% if @node_ip -%>
+ --node-ip=<%= scope['kubernetes::node::kubelet::node_ip'] -%>
+<% end -%>
+<% if @node_labels -%>
+ --node-labels=<%= scope['kubernetes::node::kubelet::node_labels'] -%>
+<% end -%>
+<% if @reconcile_cidr -%>
+ --reconcile-cidr=<%= scope['kubernetes::node::kubelet::reconcile_cidr'] -%>
+<% end -%>
+<% if @register_schedulable -%>
+ --register-schedulable=<%= scope['kubernetes::node::kubelet::register_schedulable'] -%>
+<% end -%>
+<% if @runtime_cgroups -%>
+ --runtime-cgroups=<%= scope['kubernetes::node::kubelet::runtime_cgroups'] -%>
+<% end -%>
+<% if @system_cgroups -%>
+ --system-cgroups=<%= scope['kubernetes::node::kubelet::system_cgroups'] -%>
+<% end -%>
+<% if @system_reserved -%>
+ --system-reserved=<%= scope['kubernetes::node::kubelet::system_reserved'] -%>
+<% end -%>
+<% if @non_masquerade_cidr -%>
+ --non-masquerade-cidr=<%= scope['kubernetes::node::kubelet::non_masquerade_cidr'] -%>
+<% end -%>
+<% end -%>
  <%= scope['kubernetes::node::kubelet::args'] -%>
 "

--- a/templates/etc/kubernetes/proxy.erb
+++ b/templates/etc/kubernetes/proxy.erb
@@ -24,7 +24,17 @@ KUBE_PROXY_ARGS="<% -%>
 <% if @oom_score_adj %> --oom-score-adj=<%= scope['kubernetes::node::kube_proxy::oom_score_adj'] %><% end -%>
 <% if @proxy_mode %> --proxy-mode=<%= scope['kubernetes::node::kube_proxy::proxy_mode'] %><% end -%>
  --proxy-port-range=<%= scope['kubernetes::node::kube_proxy::proxy_port_range'] -%>
+<% if @minimum_version.to_f < 1.2 then -%>
 <% if @resource_container %> --resource-container=<%= scope['kubernetes::node::kube_proxy::resource_container'] %><% end -%>
+<% end -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+<% if @config_sync_period %> --config-sync-period=<%= scope['kubernetes::node::kube_proxy::config_sync_period'] -%><% end -%>
+<% if @conntrack_max %> --conntrack-max=<%= scope['kubernetes::node::kube_proxy::conntrack_max'] -%><% end -%>
+<% if @conntrack_tcp_timeout_established %> --conntrack-tcp-timeout-established=<%= scope['kubernetes::node::kube_proxy::conntrack_tcp_timeout_established'] -%><% end -%>
+<% if @iptables_masquerade_bit %> --iptables-masquerade-bit=<%= scope['kubernetes::node::kube_proxy::iptables_masquerade_bit'] -%><% end -%>
+<% if @kube_api_burst %> --kube-api-burst=<%= scope['kubernetes::node::kube_proxy::kube_api_burst'] -%><% end -%>
+<% if @kube_api_qps %> --kube-api-qps=<%= scope['kubernetes::node::kube_proxy::kube_api_qps'] -%><% end -%>
+<% end -%>
 <% if @minimum_version.to_f > 1.0 then -%>
  --udp-timeout=<%= scope['kubernetes::node::kube_proxy::udp_timeout'] -%>
 <% end -%>

--- a/templates/etc/kubernetes/scheduler.erb
+++ b/templates/etc/kubernetes/scheduler.erb
@@ -23,7 +23,7 @@ KUBE_SCHEDULER_ARGS="<% -%>
 <% if @minimum_version.to_f >= 1.2 then -%>
 <% if @leader_elect then -%>
  --leader-elect=<%= scope['kubernetes::master::scheduler::leader_elect'] -%>
- --leader-elect-lease-duration=<%= scope['kubernetes::master::scheduler:leader_elect_lease_duration:'] -%>
+ --leader-elect-lease-duration=<%= scope['kubernetes::master::scheduler:leader_elect_lease_duration'] -%>
  --leader-elect-renew-deadline=<%= scope['kubernetes::master::scheduler::leader_elect_renew_deadline'] -%>
  --leader-elect-retry-period=<%= scope['kubernetes::master::scheduler::leader_elect_retry_period'] -%>
 <% end -%>

--- a/templates/etc/kubernetes/scheduler.erb
+++ b/templates/etc/kubernetes/scheduler.erb
@@ -20,5 +20,16 @@ KUBE_SCHEDULER_ARGS="<% -%>
  --log-flush-frequency=<%= scope['kubernetes::master::scheduler::log_flush_frequency'] -%>
  --master=<%= scope['kubernetes::master::scheduler::master'] -%>
  --port=<%= scope['kubernetes::master::scheduler::port'] -%>
+<% if @minimum_version.to_f >= 1.2 then -%>
+<% if @leader_elect then -%>
+ --leader-elect=<%= scope['kubernetes::master::scheduler::leader_elect'] -%>
+ --leader-elect-lease-duration=<%= scope['kubernetes::master::scheduler:leader_elect_lease_duration:'] -%>
+ --leader-elect-renew-deadline=<%= scope['kubernetes::master::scheduler::leader_elect_renew_deadline'] -%>
+ --leader-elect-retry-period=<%= scope['kubernetes::master::scheduler::leader_elect_retry_period'] -%>
+<% end -%>
+<% if @scheduler_name then -%>
+ --scheduler-name=<%= scope['kubernetes::master::scheduler::scheduler_name'] -%>
+<% end -%>
+<% end -%>
 <%= scope['kubernetes::master::scheduler::extra_args'] -%>
 "


### PR DESCRIPTION
Mostly new parameters, some of them really needed in 1.2 (ie. --hairpin-mode
for kubelet) ; but also some lost parameters (ie. "--etcd-config" isn't
supported anymore in 1.2, api-server lost "--cluster-name" option, ...), which
needed some care (ie. wrapping their uses with if $minimum_version) sinc
kubernetes won't start with unknown command line flags.

I don't have a < 1.2.0 cluster anymore to test against, but all new options
are enclosed by "<% if @minimum_version.to_f >= 1.2 -%>" in templates, and
I manualy verified the absence of functional changes with "$minimum_version
= 1.0" on a copy of my old configs.
