### PR TITLE
Edited quoting to pass puppet-lint

### DIFF
--- a/manifests/master/apiserver.pp
+++ b/manifests/master/apiserver.pp
@@ -505,7 +505,7 @@ class kubernetes::master::apiserver (
       docker::run { 'kube-apiserver':
         ensure           => $ensure_container,
         image            => $container_image,
-        command          => '/hyperkube apiserver ${args}',
+        command          => "/hyperkube apiserver ${args}",
         volumes          => ['/etc/pki:/etc/pki', '/etc/ssl:/etc/ssl', '/etc/kubernetes:/etc/kubernetes',],
         restart_service  => true,
         net              => 'host',

--- a/manifests/master/controller_manager.pp
+++ b/manifests/master/controller_manager.pp
@@ -472,7 +472,7 @@ class kubernetes::master::controller_manager (
       docker::run { 'kube-controller-manager':
         ensure           => $ensure_container,
         image            => $container_image,
-        command          => '/hyperkube controller-manager ${args}',
+        command          => "/hyperkube controller-manager ${args}",
         volumes          => ['/etc/pki:/etc/pki', '/etc/ssl:/etc/ssl', '/etc/kubernetes:/etc/kubernetes',],
         restart_service  => true,
         net              => 'host',

--- a/manifests/master/scheduler.pp
+++ b/manifests/master/scheduler.pp
@@ -231,7 +231,7 @@ class kubernetes::master::scheduler (
       docker::run { 'kube-scheduler':
         ensure           => $ensure_container,
         image            => $container_image,
-        command          => '/hyperkube scheduler ${args}',
+        command          => "/hyperkube scheduler ${args}",
         volumes          => ['/etc/pki:/etc/pki', '/etc/ssl:/etc/ssl', '/etc/kubernetes:/etc/kubernetes',],
         restart_service  => true,
         net              => 'host',

--- a/manifests/node/kube_proxy.pp
+++ b/manifests/node/kube_proxy.pp
@@ -261,7 +261,7 @@ class kubernetes::node::kube_proxy (
       docker::run { 'kube-proxy':
         ensure           => $ensure_container,
         image            => $container_image,
-        command          => '/hyperkube proxy ${args}',
+        command          => "/hyperkube proxy ${args}",
         volumes          => ['/etc/pki:/etc/pki', '/etc/ssl:/etc/ssl', '/etc/kubernetes:/etc/kubernetes',],
         restart_service  => true,
         net              => 'host',


### PR DESCRIPTION
My puppet-lint check failed a number of single-quoted strings with variables in them. Corrected this.